### PR TITLE
append .webp to the original filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ end
 Ignore option accepts one or an array of String globs, Regexps or
 Procs.
 
+### Append the .webp extension instead of replacing the original extension
+
+If you want the output images to be named **sample.png.webp**
+instead of **sample.webp**, set the option `append_extension` to true.
+
+``` ruby
+activate :webp do |webp|
+  webp.append_extension = true
+end
+```
+
 
 ## Configuring your site to provide WebP alternatives
 

--- a/lib/middleman-webp/converter.rb
+++ b/lib/middleman-webp/converter.rb
@@ -79,7 +79,11 @@ module Middleman
       end
 
       def destination_path(src_path)
-        dst_name = src_path.basename.to_s.gsub(SUFFIX_RE, 'webp')
+        if @options.append_extension
+          dst_name = "#{src_path.basename.to_s}.webp"
+        else
+          dst_name = src_path.basename.to_s.gsub(SUFFIX_RE, 'webp')
+        end
         src_path.parent.join(dst_name)
       end
 

--- a/lib/middleman-webp/extension.rb
+++ b/lib/middleman-webp/extension.rb
@@ -7,6 +7,8 @@ module Middleman
   class WebPExtension < Extension
     option(:conversion_options, {},
            'Custom conversion options for cwebp/gif2webp')
+    option(:append_extension, false,
+           'keep the original filename and extension and append .webp (image.png => image.png.webp)')
     option(:ignore, [], 'Ignores files with matching paths')
     option(:verbose, false, 'Display all external command which are executed '\
            'to help debugging.')

--- a/lib/middleman-webp/options.rb
+++ b/lib/middleman-webp/options.rb
@@ -3,7 +3,7 @@ require 'middleman-webp/pathname_matcher'
 module Middleman
   module WebP
     class Options
-      attr_reader :ignore, :verbose
+      attr_reader :ignore, :verbose, :append_extension
 
       def initialize(options = {})
         @ignore = options[:ignore] || []
@@ -18,6 +18,8 @@ module Middleman
         end
 
         @verbose = options[:verbose] || false
+
+        @append_extension = options[:append_extension] || false
       end
 
       # Internal: Generate command line args for cwebp or gif2webp command

--- a/spec/unit/converter_spec.rb
+++ b/spec/unit/converter_spec.rb
@@ -16,6 +16,17 @@ describe Middleman::WebP::Converter do
     end
   end
 
+  describe '#destination_path with append_extension = true' do
+    before do
+      @converter = Middleman::WebP::Converter.new(@app_mock, {append_extension: true}, nil)
+    end
+
+    it 'returns file name with same basename and webp suffix' do
+      d = @converter.destination_path(Pathname.new('build/images/sample.jpg'))
+      d.to_s.must_equal 'build/images/sample.jpg.webp'
+    end
+  end
+
   describe '#change_percentage' do
     it 'returns how many percents smaller destination file is' do
       @converter.change_percentage(10_000, 8746).must_equal '12.54 %'


### PR DESCRIPTION
This pull request adds a new option `append_extension`. If this option is set to `true`, the resulting images will be named **original.extension.webp** instead of **original.webp**.

By default `append_extension` is false and thus the resulting images will be named **original.webp**.

This fixes the issue #6
