### PR TITLE
Added support for preventing skipping of .webp files where they are larger than the source

### DIFF
--- a/lib/middleman-webp/converter.rb
+++ b/lib/middleman-webp/converter.rb
@@ -15,7 +15,9 @@ module Middleman
         @original_size = 0
         @converted_size = 0
         convert_images(image_files) do |src, dst|
-          next reject_file(dst) if dst.size >= src.size
+          if !!@options.allow_skip && dst.size >= src.size
+            next reject_file(dst)
+          end
 
           @original_size += src.size
           @converted_size += dst.size

--- a/lib/middleman-webp/extension.rb
+++ b/lib/middleman-webp/extension.rb
@@ -12,6 +12,7 @@ module Middleman
     option(:ignore, [], 'Ignores files with matching paths')
     option(:verbose, false, 'Display all external command which are executed '\
            'to help debugging.')
+    option(:allow_skip, true, 'Skip saving .webp files which are larger than their source')
 
     def initialize(app, options_hash = {}, &block)
       super

--- a/lib/middleman-webp/options.rb
+++ b/lib/middleman-webp/options.rb
@@ -20,7 +20,7 @@ module Middleman
         @verbose = options[:verbose] || false
 
         @append_extension = options[:append_extension] || false
-        @allow_skip = options[:allow_skip] || false
+        @allow_skip = !(false == options[:allow_skip])
       end
 
       # Internal: Generate command line args for cwebp or gif2webp command

--- a/lib/middleman-webp/options.rb
+++ b/lib/middleman-webp/options.rb
@@ -3,7 +3,7 @@ require 'middleman-webp/pathname_matcher'
 module Middleman
   module WebP
     class Options
-      attr_reader :ignore, :verbose, :append_extension
+      attr_reader :ignore, :verbose, :append_extension, :allow_skip
 
       def initialize(options = {})
         @ignore = options[:ignore] || []
@@ -20,6 +20,7 @@ module Middleman
         @verbose = options[:verbose] || false
 
         @append_extension = options[:append_extension] || false
+        @allow_skip = options[:allow_skip] || false
       end
 
       # Internal: Generate command line args for cwebp or gif2webp command

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -3,6 +3,18 @@ require 'pathname'
 require_relative '../../lib/middleman-webp/options'
 
 describe Middleman::WebP::Options do
+  describe '#allow_skip' do
+    it "should default to false" do
+      options = Middleman::WebP::Options.new
+      options.allow_skip.must_equal(false)
+    end
+    
+    it "should allow setting to true" do
+      options = Middleman::WebP::Options.new(allow_skip: true)
+      options.allow_skip.must_equal(true)
+    end
+  end
+  
   describe '#for' do
     it 'returns cwebp args when given file matches option file pattern glob' do
       path = Pathname.new('test_image.jpg')

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -4,14 +4,14 @@ require_relative '../../lib/middleman-webp/options'
 
 describe Middleman::WebP::Options do
   describe '#allow_skip' do
-    it "should default to false" do
+    it "should default to true" do
       options = Middleman::WebP::Options.new
-      options.allow_skip.must_equal(false)
+      options.allow_skip.must_equal(true)
     end
     
     it "should allow setting to true" do
-      options = Middleman::WebP::Options.new(allow_skip: true)
-      options.allow_skip.must_equal(true)
+      options = Middleman::WebP::Options.new(allow_skip: false)
+      options.allow_skip.must_equal(false)
     end
   end
   


### PR DESCRIPTION
I've had a few issues where I've deployed builds of my sites and imagery has broken due to WebP files not being generated, and the build assuming they would be in-place.

After digging, it was due to those larger than their source being skipped. This is a good idea as the whole point of WebP is that it's smaller than other formats, but it has become a maintenance nightmare, so I'm submitting this patch which keeps the current behaviour as default, but adds a configuration option to force generation regardless of output size.

Hope this helps others.