### PR TITLE
update osx install

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ install those first for your system.
 
 - Fedora: ```yum install libwebp-tools```
 - Ubuntu: ```apt-get install webp```
-- OS X: ```brew install webp```
+- OS X: ```brew install webp --with-giflib```
 - Or install from the Google's WebP site:
   https://developers.google.com/speed/webp/download
 


### PR DESCRIPTION
In order to get gif2webp, we need to pass ```--with-giflib``` option