### PR TITLE
Support Middleman 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ rvm:
 script: bundle exec rake test
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install webp
+  - sudo apt-get install -y webp

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ dist: trusty
 language: ruby
 rvm:
   - 2.0.0
-  - 2.1.8
-  - 2.2.4
-  - 2.3.0
+  - 2.1.7
+  - 2.2.3
 script: bundle exec rake test
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: required
+dist: trusty
 language: ruby
 rvm:
   - 2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## 0.4.0
+
+- Middleman 4.0.0 compatibility
+- *Breaks* Middleman 3.*.* support, use gem version 0.3.2 with older
+  Middleman versions
+
 ## 0.3.0
 
 - Add new option: run_before_build with default value false (ie. default

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ Add this line to your Middleman site's Gemfile:
 
     gem 'middleman-webp'
 
+You are not able to use latest gem version if you are using **Middleman 3**. In
+that case install gem with following Gemfile statement:
+
+    gem 'middleman-webp', '~> 0.3.2'
+
 And then execute:
 
     $ bundle

--- a/lib/middleman-webp/extension.rb
+++ b/lib/middleman-webp/extension.rb
@@ -1,4 +1,5 @@
 require 'middleman-core'
+require 'middleman-webp/logger'
 require 'middleman-webp/converter'
 
 require 'shell'
@@ -22,34 +23,45 @@ module Middleman
 
     def before_build(builder)
       return unless options[:run_before_build]
-      return unless dependencies_installed?(builder)
-      Middleman::WebP::Converter.new(@app, options, builder).convert
+
+      initialize_logger builder
+      return unless dependencies_installed?
+      Middleman::WebP::Converter.new(@app, options, builder, @logger).convert
     end
 
     def after_build(builder)
       return if options[:run_before_build]
-      return unless dependencies_installed?(builder)
-      Middleman::WebP::Converter.new(@app, options, builder).convert
+
+      initialize_logger builder
+      return unless dependencies_installed?
+      Middleman::WebP::Converter.new(@app, options, builder, @logger).convert
     end
 
     # Internal: Check that cwebp and gif2webp commandline tools are available.
     #
     # Returns true if all is OK.
-    def dependencies_installed?(builder)
-      sh = Shell.new
+    def dependencies_installed?
+      warn_if_gif2webp_missing
+      cwebp_installed?
+    end
 
-      begin
-        sh.find_system_command('gif2webp')
-      rescue Shell::Error::CommandNotFound => e
-        builder.say_status :webp, "#{e.message} Please install latest version of webp library and tools to get gif2webp and be able to convert gif files also.", :red
-      end
+    def initialize_logger(builder)
+      @logger = Middleman::WebP::Logger.new(builder, verbose: @options.verbose)
+    end
 
-      begin
-        true if sh.find_system_command('cwebp')
-      rescue Shell::Error::CommandNotFound => e
-        builder.say_status :webp, "ERROR: #{e.message} Please install cwebp and gif2webp commandline tools first.", :red
-        false
-      end
+    private
+
+    def warn_if_gif2webp_missing
+      Shell.new.find_system_command('gif2webp')
+    rescue Shell::Error::CommandNotFound => e
+      @logger.error "#{e.message} Please install latest version of webp library and tools to get gif2webp and be able to convert gif files also."
+    end
+
+    def cwebp_installed?
+      true if Shell.new.find_system_command('cwebp')
+    rescue Shell::Error::CommandNotFound => e
+      @logger.error "ERROR: #{e.message} Please install cwebp and gif2webp commandline tools first."
+      false
     end
   end
 end

--- a/lib/middleman-webp/logger.rb
+++ b/lib/middleman-webp/logger.rb
@@ -1,0 +1,26 @@
+module Middleman
+  module WebP
+    class Logger
+      def initialize(builder, opts = {})
+        @builder = builder
+        @options = opts
+      end
+
+      def info(msg, color = nil)
+        @builder.thor.say_status :webp, msg, color
+      end
+
+      def error(msg)
+        info msg, :red
+      end
+
+      def warn(msg)
+        info msg, :yellow
+      end
+
+      def debug(msg)
+        info msg if @options[:verbose]
+      end
+    end
+  end
+end

--- a/lib/middleman-webp/version.rb
+++ b/lib/middleman-webp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module Webp
-    VERSION = '0.3.2'
+    VERSION = '0.4.0'
   end
 end

--- a/middleman-webp.gemspec
+++ b/middleman-webp.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "middleman-core", ">= 3.3.0", "< 3.5.0"
+  spec.add_dependency "middleman-core", "~> 4.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "middleman-cli", "~> 4.0.0"
   spec.add_development_dependency "rake"
   #spec.add_development_dependency "simplecov"
   spec.add_development_dependency "mocha"

--- a/spec/unit/converter_spec.rb
+++ b/spec/unit/converter_spec.rb
@@ -5,7 +5,7 @@ require_relative '../../lib/middleman-webp/converter'
 
 describe Middleman::WebP::Converter do
   before do
-    @app_mock = stub(inst: stub(build_dir: 'spec/fixtures/dummy-build'))
+    @app_mock = stub(config: {build_dir: 'spec/fixtures/dummy-build'})
     @converter = Middleman::WebP::Converter.new(@app_mock, {}, nil)
   end
 
@@ -18,7 +18,7 @@ describe Middleman::WebP::Converter do
 
   describe '#destination_path with append_extension = true' do
     before do
-      @converter = Middleman::WebP::Converter.new(@app_mock, {append_extension: true}, nil)
+      @converter = Middleman::WebP::Converter.new(@app_mock, {append_extension: true}, nil, nil)
     end
 
     it 'returns file name with same basename and webp suffix' do
@@ -60,12 +60,9 @@ describe Middleman::WebP::Converter do
     end
 
     it 'uses cwebp for jpeg, png and tiff files' do
-      path = Pathname.new('/some/path/image.jpg')
-      @converter.tool_for(path).must_equal 'cwebp'
-      path = Pathname.new('/some/path/image.png')
-      @converter.tool_for(path).must_equal 'cwebp'
-      path = Pathname.new('/some/path/image.tiff')
-      @converter.tool_for(path).must_equal 'cwebp'
+      @converter.tool_for(Pathname('/some/path/image.jpg')).must_equal 'cwebp'
+      @converter.tool_for(Pathname('/some/path/image.png')).must_equal 'cwebp'
+      @converter.tool_for(Pathname('/some/path/image.tiff')).must_equal 'cwebp'
     end
   end
 
@@ -77,9 +74,9 @@ describe Middleman::WebP::Converter do
     it 'won\'t include ignored files' do
       @converter = Middleman::WebP::Converter.new(@app_mock, {
                                                     ignore: [/jpg$/, '**/*.gif']
-                                                  }, nil)
+                                                  }, nil, nil)
 
-      files_to_include = [Pathname.new('spec/fixtures/dummy-build/empty.png')]
+      files_to_include = [Pathname('spec/fixtures/dummy-build/empty.png')]
       @converter.image_files.must_equal files_to_include
     end
 
@@ -87,7 +84,7 @@ describe Middleman::WebP::Converter do
       options = {
         ignore: ->(path) { path.end_with? 'jpg' }
       }
-      @converter = Middleman::WebP::Converter.new(@app_mock, options, nil)
+      @converter = Middleman::WebP::Converter.new(@app_mock, options, nil, nil)
 
       @converter.image_files.size.must_equal 2
     end

--- a/spec/unit/extension_spec.rb
+++ b/spec/unit/extension_spec.rb
@@ -1,12 +1,9 @@
 require 'spec_helper'
-#require 'pathname'
-#require 'middleman-core'
 require_relative '../../lib/middleman-webp/extension'
 
 describe Middleman::WebPExtension do
 
   before do
-    #Middleman::Extension.any_instance.expects(:initialize).returns(true)
     app_mock = stub({
                       initialized: '',
                       instance_available: true,
@@ -15,6 +12,7 @@ describe Middleman::WebPExtension do
                       after_build: nil
                     })
     @extension = Middleman::WebPExtension.new(app_mock)
+    @extension.initialize_logger(stub(thor: {say_status: nil}))
   end
 
   describe '#dependencies_installed?' do
@@ -22,27 +20,23 @@ describe Middleman::WebPExtension do
       Shell.any_instance.expects(:find_system_command).with('cwebp').returns('/usr/bin/cwebp')
       Shell.any_instance.expects(:find_system_command).with('gif2webp').returns('/usr/bin/gif2webp')
 
-      @extension.dependencies_installed?(stub(say_status: '')).must_equal true
+      @extension.dependencies_installed?.must_equal true
     end
 
     it 'returns false and displays error if cwebp is missing' do
       Shell.any_instance.expects(:find_system_command).with('cwebp').raises(Shell::Error::CommandNotFound)
       Shell.any_instance.stubs(:find_system_command).with('gif2webp').returns('/usr/bin/gif2webp')
 
-      builder_mock = stub(:say_status)
-      builder_mock.stubs(:say_status).once
-
-      @extension.dependencies_installed?(builder_mock).must_equal false
+      Middleman::WebP::Logger.any_instance.expects(:error).once
+      @extension.dependencies_installed?.must_equal false
     end
 
     it 'displays error if only gif2webp is missing and returns still true' do
       Shell.any_instance.expects(:find_system_command).with('gif2webp').raises(Shell::Error::CommandNotFound)
       Shell.any_instance.stubs(:find_system_command).with('cwebp').returns('/usr/bin/cwebp')
 
-      builder_mock = stub(:say_status)
-      builder_mock.stubs(:say_status).once
-
-      @extension.dependencies_installed?(builder_mock).must_equal true
+      Middleman::WebP::Logger.any_instance.expects(:error).once
+      @extension.dependencies_installed?.must_equal true
     end
   end
 

--- a/spec/unit/logger_spec.rb
+++ b/spec/unit/logger_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'pathname'
+require_relative '../../lib/middleman-webp/logger'
+
+describe Middleman::WebP::Logger do
+  before do
+    @thor_mock = stub({say_status: nil})
+    @logger = Middleman::WebP::Logger.new(stub({thor: @thor_mock}))
+  end
+
+  it "logs info message through Thor with given color" do
+    @thor_mock.expects(:say_status).once.with do |action, msg, color|
+      msg == 'foobar' && color == :blue
+    end
+    @logger.info 'foobar', :blue
+  end
+
+  [[:error, :red], [:warn, :yellow]].each do |(method, color)|
+    it "##{method} logs message with color #{color}" do
+      @thor_mock.expects(:say_status).once.with do |action, msg, col|
+        msg == "#{method} message" && col == color
+      end
+      @logger.send method, "#{method} message"
+    end
+  end
+
+  it "logs error with red" do
+    @thor_mock.expects(:say_status).once.with do |action, msg, color|
+      msg == 'foobar' && color == :red
+    end
+    @logger.error 'foobar'
+  end
+end


### PR DESCRIPTION
- Use Middleman builder interface in version 4 compatible way. This
  breaks backwards compatibility with Middleman 3.
- Fix source and build dir access to match Middleman 4 behavior
- Refactor build log output to decrease codebase area which would be
  affected by Middleman's interface changes

Fixes #11 