### PR TITLE
Avoid contract violation

### DIFF
--- a/lib/middleman-webp/converter.rb
+++ b/lib/middleman-webp/converter.rb
@@ -60,7 +60,7 @@ module Middleman
 
       def print_summary
         savings = @original_size - @converted_size
-        @builder.trigger :webp, nil, 'Total conversion savings: '\
+        @builder.trigger :webp, '', 'Total conversion savings: '\
           "#{number_to_human_size(savings)} "\
           "(#{change_percentage(@original_size, @converted_size)})"
       end


### PR DESCRIPTION
Hi,

Thanks for your great work. But I found that it will raise an error with Middleman 4.1.9. You have to use empty string to replace the nil to avoid contract violation

```
$ middleman build
== Blog Sources: /blog/{year}{month}{day}/{title}/index.html (:prefix + :sources)
      create  /Users/novtopro/Documents/Devcenter/novtopro.github.io/source/blog/20160609/migration/migration.webp (27.17 % smaller)
      create  /Users/novtopro/Documents/Devcenter/novtopro.github.io/source/images/avatar.webp (71.8 % smaller)
      create  /Users/novtopro/Documents/Devcenter/novtopro.github.io/source/images/loader.webp (51.76 % smaller)
/Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/contracts-0.13.0/lib/contracts.rb:48:in `block in <class:Contract>': Contract violation for argument 2 of 3: (ParamContractError)
        Expected: (String or Pathname),
        Actual: nil
        Value guarded in: Middleman::Builder::trigger
        With Contract: Symbol, Or, Maybe => Any
        At: /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/middleman-core-4.1.9/lib/middleman-core/builder.rb:296
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/contracts-0.13.0/lib/contracts.rb:154:in `failure_callback'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/contracts-0.13.0/lib/contracts/method_handler.rb:143:in `rescue in block in redefine_method'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/contracts-0.13.0/lib/contracts/method_handler.rb:136:in `block in redefine_method'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/middleman-cli-4.1.9/lib/middleman-cli/build.rb:80:in `block in build'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/activesupport-4.2.6/lib/active_support/notifications.rb:166:in `instrument'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/middleman-core-4.1.9/lib/middleman-core/util.rb:21:in `instrument'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/middleman-cli-4.1.9/lib/middleman-cli/build.rb:79:in `build'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `block in invoke_all'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `each'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `map'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/invocation.rb:133:in `invoke_all'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/group.rb:232:in `dispatch'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/invocation.rb:115:in `invoke'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor.rb:40:in `block in register'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/gems/middleman-cli-4.1.9/bin/middleman:72:in `<top (required)>'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/bin/middleman:23:in `load'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/bin/middleman:23:in `<main>'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/bin/ruby_executable_hooks:15:in `eval'
	from /Users/novtopro/.rvm/gems/ruby-2.3.1@novtopro.github.io/bin/ruby_executable_hooks:15:in `<main>'
```