### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## 1.0.0
 
 - Add support for Ruby 2.7, 3,0, 3.1, 3.2
 - *Breaks* Drop support for Ruby 2.4

--- a/README.md
+++ b/README.md
@@ -36,11 +36,6 @@ Add this line to your Middleman site's Gemfile:
 
     gem 'middleman-webp'
 
-You are not able to use latest gem version if you are using **Middleman 3**. In
-that case install gem with following Gemfile statement:
-
-    gem 'middleman-webp', '~> 0.3.2'
-
 And then execute:
 
     $ bundle
@@ -50,6 +45,21 @@ And activate :webp extension in your config.rb:
 ``` ruby
 activate :webp
 ```
+
+### Using with old Middleman 3
+
+You are not able to use latest gem version if you are using **Middleman 3**. In
+that case install gem with following Gemfile statement:
+
+    gem 'middleman-webp', '~> 0.3.2'
+    
+    
+### Using with Rubies <= 2.4
+
+Support for Rubies <= 2.4 was dropped in 1.0.0 version of this gem. If you are
+unable to update Ruby version use following Gemfile statement.
+
+    gem 'middleman-webp', '< 1.0.0'
 
 ## Options
 

--- a/lib/middleman-webp/version.rb
+++ b/lib/middleman-webp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module Webp
-    VERSION = '0.4.3'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end


### PR DESCRIPTION
Major version number bump because of the dropped Ruby <= 2.4 support.