### PR TITLE
Fix `PathnameMatcher` comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.2
+
+- Fix logic for selecting command line args for the most precise filename
+  pattern, if multiple patterns would match
+
+## 1.0.1
+
+- Add `required_ruby_version` to gemspec.
+
 ## 1.0.0
 
 - Add support for Ruby 2.7, 3,0, 3.1, 3.2

--- a/lib/middleman-webp/options.rb
+++ b/lib/middleman-webp/options.rb
@@ -35,7 +35,7 @@ module Middleman
 
         return '' if matching.empty?
 
-        matching.sort { |(ga, _oa), (gb, _ob)| gb.size <=> ga.size }[0][1]
+        matching.max_by { |(pathname_matcher, _oa)| pathname_matcher }[1]
       end
 
       private

--- a/lib/middleman-webp/version.rb
+++ b/lib/middleman-webp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module Webp
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.0.2'.freeze
   end
 end

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -54,5 +54,23 @@ describe Middleman::WebP::Options do
       args = options.for(path)
       value(args).must_match(/^-q 85$/)
     end
+
+    it 'selects most precise file pattern to get file specific option overrides correctly' do
+      path = Pathname.new('lizard.jpg')
+      options_hash = {
+        conversion_options: {
+          '*.jpg' => {
+            q: 85
+          },
+          'lizard.jpg' => {
+            q: 100
+          }
+        }
+      }
+      options = Middleman::WebP::Options.new options_hash
+
+      args = options.for(path)
+      value(args).must_match(/^-q 100$/)
+    end
   end
 end

--- a/spec/unit/pathname_matcher_spec.rb
+++ b/spec/unit/pathname_matcher_spec.rb
@@ -54,4 +54,32 @@ describe Middleman::WebP::PathnameMatcher do
       Middleman::WebP::PathnameMatcher.new('*.jpg').matches? nil
     end
   end
+
+  describe '#<=>' do
+    it 'sorts by pattern length' do
+      patterns = ['*.jpg', 'really_long_example_name.jpg', %r{^images/.*\.jpg$}]
+      matchers = patterns.map { |p| Middleman::WebP::PathnameMatcher.new(p) }
+
+      sorted_matchers = matchers.sort
+
+      value(sorted_matchers.map(&:pattern)).must_equal(patterns.sort_by { |p| p.to_s.length })
+    end
+
+    it 'sorts proc pattern smaller than string' do
+      patterns = ['*.jpg', Proc.new { |p| p == 'jpg' }, %r{^images/.*\.jpg$}]
+      matchers = patterns.map { |p| Middleman::WebP::PathnameMatcher.new(p) }
+      min_value = matchers.min
+
+      value(min_value.pattern).must_equal(patterns[1])
+    end
+
+    it 'considers any procs equal' do
+      proc1 = Proc.new { |p| p == 'jpg' }
+      proc2 = Proc.new { |p| p == 'png' }
+      matcher1 = Middleman::WebP::PathnameMatcher.new(proc1)
+      matcher2 = Middleman::WebP::PathnameMatcher.new(proc2)
+
+      value(matcher1 <=> matcher2).must_equal 0
+    end
+  end
 end


### PR DESCRIPTION
Fix logic for selecting command line args for the most precise filename pattern, if multiple patterns would match